### PR TITLE
Fixes some tests, important update to Harbor::View.exists?, Erubis is default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - jruby-19mode

--- a/lib/harbor/view.rb
+++ b/lib/harbor/view.rb
@@ -1,3 +1,4 @@
+require "erubis"
 require "tilt"
 
 require_relative "view_context"
@@ -86,7 +87,7 @@ module Harbor
       template = if self.class.cache_templates?
         self.class.tilt_cache.fetch(full_path) { Tilt.new(full_path) }
       else
-        Tilt.new(full_path.to_s)
+        Tilt.new(full_path.to_s, :engine_class => Erubis::FastEruby)
       end
       template.render(context)
     end

--- a/lib/harbor/view.rb
+++ b/lib/harbor/view.rb
@@ -45,6 +45,8 @@ module Harbor
     end
 
     def self.exists?(filename)
+      return false if self.path.none?
+
       extension = ::File.extname(filename)
       file_pattern = filename
       file_pattern << ".html.{#{self.engines.join(',')}}" if extension.empty?

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1,4 +1,5 @@
 require_relative "helper"
+require "erubis"
 
 class FormHelperTest < MiniTest::Unit::TestCase
   def test_basic_form

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -1,5 +1,4 @@
 require_relative "helper"
-require "erubis"
 
 class FormHelperTest < MiniTest::Unit::TestCase
   def test_basic_form

--- a/test/harbor_test_test.rb
+++ b/test/harbor_test_test.rb
@@ -5,6 +5,14 @@ class HarborTestTest < MiniTest::Unit::TestCase
 
   include Harbor::Test
 
+  def setup
+    Harbor::View::path.unshift Pathname(__FILE__).dirname + "views"
+  end
+
+  def teardown
+    Harbor::View::path.clear
+  end
+
   # ASSERTIONS
   def test_assert_redirect_success
     response = Harbor::Test::Response.new

--- a/test/view_test.rb
+++ b/test/view_test.rb
@@ -11,6 +11,19 @@ class ViewTest < MiniTest::Unit::TestCase
     Harbor::View::engines.delete "str"
   end
 
+  def test_view_exists
+    assert Harbor::View.exists?("index.html.erb")
+  end
+
+  def test_view_doesnt_exist
+    refute Harbor::View.exists?("somefilethatdoesnotexist")
+  end
+
+  def test_empty_view_path
+    Harbor::View::path.clear
+    refute Harbor::View.exists?("index.html.erb")
+  end
+
   def test_render_with_variables
     view = Harbor::View.new("index", :text => "test")
     assert_equal("test", view.to_s)

--- a/test/view_test.rb
+++ b/test/view_test.rb
@@ -65,4 +65,9 @@ class ViewTest < MiniTest::Unit::TestCase
   def test_supports_javascript_templates
     flunk
   end
+
+  def test_supports_erubis_templates
+    view = Harbor::View.new("erubis_test.erubis")
+    assert_equal("Erubis::FastEruby", view.to_s)
+  end
 end

--- a/test/views/erubis_test.erubis
+++ b/test/views/erubis_test.erubis
@@ -1,0 +1,1 @@
+<%= Erubis::FastEruby %>


### PR DESCRIPTION
If nothing is in Harbor::View.paths, you end up w/ a glob like {}/**/index.html.erb, which searches all the things.  That, plus fixes a couple Form Helper tests.
