### PR TITLE
Add ruby 1.9.3 to travis build and status image to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
+  - 1.9.3
   - jruby-19mode

--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 == Welcome to Harbor!
 
+https://secure.travis-ci.org/sam/harbor.png
+
 For information on getting started, check out: http://wiecklabs.com/get-started
 
 Some of the most important classes you'll probably want to check out are:


### PR DESCRIPTION
According to http://about.travis-ci.org/docs/user/status-images/ the image should work, but as we are not using any templating i'm not sure it will :-P
