### PR TITLE
Code coverage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,12 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
+desc "Run tests with code coverage enabled"
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task["test"].execute
+end
+
 task :rdoc do
   sh <<EOS.strip
 rdoc -T harbor#{" --op " + ENV["OUTPUT_DIRECTORY"] if ENV["OUTPUT_DIRECTORY"]} --line-numbers --main README --title "Harbor Documentation" --exclude "lib/harbor/commands/*" lib/harbor.rb lib/harbor README

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,11 @@ end
 
 desc "Run tests with code coverage enabled"
 task :coverage do
+  if RUBY_PLATFORM =~ /java/
+    puts "Simplecov doesn't play well with Java, see http://jira.codehaus.org/browse/JRUBY-6106 for more info"
+    exit(1)
+  end
+
   ENV['COVERAGE'] = 'true'
   Rake::Task["test"].execute
 end

--- a/harbor.gemspec
+++ b/harbor.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "testdrive"
   s.add_development_dependency "rake"
   s.add_development_dependency "uuid"
+  s.add_development_dependency "simplecov"
   s.add_development_dependency "rdoc", ">= 2.4.2"
   s.add_development_dependency "erubis"
   s.add_development_dependency "redis_directory", ">= 1.0.4"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,13 @@
 require "rubygems"
 require "bundler/setup"
 
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+end
+
 require "pathname"
 require "minitest/autorun"
 require "uri"


### PR DESCRIPTION
I was planning to use `rcov` but it is not supported on 1.9, the only problem is that jruby with 1.9 support [doesn't play well with built in code coverage](http://jira.codehaus.org/browse/JRUBY-6106) and we end up getting different numbers for jruby (100%) and MRI (80%) o0
