### PR TITLE
Avoid requiring controllers one by one and require all files on /controllers

### DIFF
--- a/lib/harbor/commands/skeletons/default/lib/appname.rb
+++ b/lib/harbor/commands/skeletons/default/lib/appname.rb
@@ -19,4 +19,6 @@ class <@= app_class @> < Harbor::Application
 
 end
 
-require_relative "../controllers/home"
+Dir[Pathname(__FILE__).dirname.parent + 'controllers/*.rb'].each do |controller|
+  require controller
+end

--- a/test/harbor_setup_command_test.rb
+++ b/test/harbor_setup_command_test.rb
@@ -100,7 +100,9 @@ class HarborSetupCommandTest < MiniTest::Unit::TestCase
 
       end
 
-      require_relative "../controllers/home"
+      Dir[Pathname(__FILE__).dirname.parent + 'controllers/*.rb'].each do |controller|
+        require controller
+      end
     RUBY
   end
 


### PR DESCRIPTION
This will make the generated app require all controllers from controllers folder so we don't need to remember to add a `require_relative "../controllers/<new_controller>"` to `lib/<app_name>.rb`
