### PR TITLE
Fixing #72

### DIFF
--- a/lib/harbor/commands/server.rb
+++ b/lib/harbor/commands/server.rb
@@ -3,5 +3,13 @@ require_relative 'boot'
 if RUBY_PLATFORM =~ /java/
   require_relative "../jetty"
 else
-  Rack::Server.start(Port: 9292, config: "config.ru", environment: config.environment)
+  options = {
+    :environment => config.environment,
+    :pid         => nil,
+    :Port        => 9292,
+    :Host        => "0.0.0.0",
+    :AccessLog   => [],
+    :config      => "config.ru"
+  }
+  Rack::Server.start(options)
 end


### PR DESCRIPTION
Apparently WEBrick tries to bind to the same "address" multiple times if we don't specify the :Host and outputs logging information to `$stderr` if :AccessLog is not set
